### PR TITLE
Add default values for firstName and lastName

### DIFF
--- a/Controllers/ProfileController.cs
+++ b/Controllers/ProfileController.cs
@@ -11,8 +11,8 @@ public class ProfileController : ControllerBase
     {
         // The email claim is usually present if you use Identity
         var email = User.Identity?.Name ?? User.Claims.FirstOrDefault(c => c.Type == "email")?.Value;
-        var firstName = User.Claims.FirstOrDefault(c => c.Type == "given_name")?.Value;
-        var lastName = User.Claims.FirstOrDefault(c => c.Type == "family_name")?.Value;
+        var firstName = User.Claims.FirstOrDefault(c => c.Type == "given_name")?.Value ?? "First Name not provided";
+        var lastName = User.Claims.FirstOrDefault(c => c.Type == "family_name")?.Value ?? "Last Name not provided";
 
         if (email == null)
             return NotFound("Email not found.");


### PR DESCRIPTION
Updated `ProfileController.cs` to provide default values for `firstName` and `lastName` when the corresponding claims are not present. This change ensures that these variables always contain meaningful strings instead of being `null`.